### PR TITLE
Fixed wall height conversion not obeying Grid Scale in Scene Settings

### DIFF
--- a/module/layers/terrain-height-layer.mjs
+++ b/module/layers/terrain-height-layer.mjs
@@ -3,6 +3,7 @@ import { flags, moduleName, tools, wallHeightModuleName } from "../consts.mjs";
 import { HeightMap } from "../geometry/height-map.mjs";
 import { convertConfig$, eraseConfig$, paintingConfig$ } from "../stores/drawing.mjs";
 import { Signal } from "../utils/signal.mjs";
+import { toSceneUnits } from "../utils/grid-utils.mjs";
 import { getTerrainType } from "../utils/terrain-types.mjs";
 import { GridHighlightGraphics } from "./grid-highlight-graphics.mjs";
 import { TerrainHeightGraphics } from "./terrain-height-graphics.mjs";
@@ -488,7 +489,7 @@ export class TerrainHeightLayer extends InteractionLayer {
 
 		if (toWalls) {
 			const flags = setWallHeightFlags && game.modules.get(wallHeightModuleName)?.active
-				? { "wall-height": { top: shape.top, bottom: shape.bottom } }
+				? { "wall-height": { top: toSceneUnits(shape.top), bottom: toSceneUnits(shape.bottom) } }
 				: {};
 
 			await canvas.scene.createEmbeddedDocuments("Wall", [...shape.polygon.edges, ...shape.holes.flatMap(h => h.edges)]


### PR DESCRIPTION
Fixed issue where converted walls were not using the Grid Scale set in the Scene Settings when setting their height.
<img width="1286" height="320" alt="image" src="https://github.com/user-attachments/assets/ef11e78e-4072-4704-8d27-377e294665c9" />

# Fixes:
- #27 