### PR TITLE
Compact Terrain Stack Fixes

### DIFF
--- a/src/applications/terrain-stack-viewer.mjs
+++ b/src/applications/terrain-stack-viewer.mjs
@@ -13,6 +13,7 @@ import { allTerrainShapes$, getShapesAtPoint } from "../stores/terrain-manager.m
 import { getCssColorsFor, getTerrainType } from "../stores/terrain-types.mjs";
 import { toSceneUnits } from "../utils/grid-utils.mjs";
 import { LitApplicationMixin } from "./mixins/lit-application-mixin.mjs";
+import { prettyFraction } from "../utils/misc-utils.mjs";
 
 // How many pixels each unit in height is represented by in proportional mode.
 const proportionalModeScale = 28;
@@ -219,7 +220,7 @@ export class TerrainStackViewer extends LitApplicationMixin(ApplicationV2) {
 		return html`${shapes.map(({ shape, terrainType, style: { color, borderColor, background } }) => html`
 			<div class="terrain-layer-block" style=${styleMap({ color, borderColor, background })}>
 				<p class="terrain-layer-block-title">${terrainType.name}</p>
-				<p class="terrain-layer-block-height">${f(shape.bottom)} → ${f(shape.bottom)} (${l("Height")} ${f(shape.height)})</p>
+				<p class="terrain-layer-block-height">${f(shape.bottom)} → ${f(shape.top)} (${l("Height")} ${f(shape.height)})</p>
 			</div>
 		`)}`;
 	}


### PR DESCRIPTION
Currently, the below error throws when trying to use the Compact Terrain Stack Viewer. Additionally, were it to succeed it renders only "{bottomHeight} -> {bottomHeight}" rather than the intended range of the terrain. This PR fixes both of these issues.
<img width="514" height="96" alt="image" src="https://github.com/user-attachments/assets/fe52b4e4-d86a-4c19-bfe9-7f60fe4aed9f" />
<img width="228" height="129" alt="image" src="https://github.com/user-attachments/assets/f68d82e8-5274-485d-95e5-d31444d99d59" />

