### PR TITLE
Fix token name color in light theme for Line of Sight toolbar

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -483,7 +483,7 @@
 	color: var(--color-light-3);
 }
 
-.themed.theme-light {
+.themed.theme-light #tht_tokenLineOfSightToolbar .token-name {
 	color: var(--color-dark-2);
 }
 


### PR DESCRIPTION
Makes the styling on the light mode grey tighter.

Closes https://github.com/Wibble199/FoundryVTT-Terrain-Height-Tools/issues/37